### PR TITLE
fix number of arguments in error

### DIFF
--- a/flmatrix.rkt
+++ b/flmatrix.rkt
@@ -205,7 +205,7 @@
         (define a   (flmatrix-a A1))
         (define lda (flmatrix-lda A1)))]
     [_
-     (error)]))
+     (syntax/loc stx (error "Wrong number of arguments"))]))
 
 ;;;
 ;;; MEMORY LAYOUT


### PR DESCRIPTION
Fixes the syntax error
```racket
(define-param (a b c d e) 'x)
```
on the number of arguments